### PR TITLE
Removed duplicate Keras (Python) pdf under Deep Learning / R category…

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,9 +270,6 @@ From @afshinea:
 
 ![](https://github.com/FavioVazquez/ds-cheatsheets/blob/master/R/RStudio/img/keras.png)
 
-- [Keras Datacamp (PDF)](https://github.com/FavioVazquez/ds-cheatsheets/blob/master/Deep_Learning/keras_datacamp.pdf)
-
-![](https://github.com/FavioVazquez/ds-cheatsheets/blob/master/Deep_Learning/img/keras_datacamp-1.png)
 
 ## Python
 


### PR DESCRIPTION
…. Now, it is shown under only Python.

Related to issue #4 